### PR TITLE
fix(custom): 左右布局删除模块视图未更新

### DIFF
--- a/src/views/custom/components/ModelBox.vue
+++ b/src/views/custom/components/ModelBox.vue
@@ -18,7 +18,7 @@
         </div>
       </el-tooltip>
       <el-tooltip class="box-item" effect="dark" content="删除当前模块">
-        <div class="delete" @click.stop="useDeleteModel(item)">
+        <div class="delete" @click.stop="delModel">
           <svg-icon
             icon-name="icon-shanchu"
             class-name="icon icon-shanchu"
@@ -114,7 +114,7 @@
     }
   };
 
-  // 传统布局删除
+  // 传统布局添加
   const classicalAdd = () => {
     let index: number = resumeJsonNewStore.value.COMPONENTS.findIndex(
       (item) => item.keyId === props.item.keyId
@@ -122,6 +122,19 @@
     let insert = cloneDeep(props.item);
     insert.keyId = getUuid();
     resumeJsonNewStore.value.COMPONENTS.splice(index, 0, insert);
+  };
+
+  // 删除当前模块
+  const delModel = () => {
+    if (resumeJsonNewStore.value.LAYOUT === 'classical') {
+      classicalDelete();
+    } else {
+      emit('leftRightDelete', props.item);
+    }
+  };
+  // 传统布局删除模块
+  const classicalDelete = () => {
+    useDeleteModel(props.item);
   };
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
这个问题是跟https://github.com/Hacker233/resume-design/issues/217 一样的问题，主要是因为cutom页面中也用了逻辑相同的ModelBox组件